### PR TITLE
FIX : Remove useless parts of script

### DIFF
--- a/class/actions_discountrules.class.php
+++ b/class/actions_discountrules.class.php
@@ -160,7 +160,8 @@ class Actionsdiscountrules
 									}
 
 
-									discountTooltip = discountTooltip + "<br/><?php print $langs->transnoentities('Discount'); ?> : " +  data.reduction + "%";
+									discountTooltip = discountTooltip + "<br/><?php print $langs->transnoentities('Discount'); ?> : " +  data.reduction + "%"
+													 + "<br/><?php print $langs->transnoentities('FromQty'); ?> : " +   data.from_quantity;
 
 									if(data.fk_product > 0) {
 										discountTooltip = discountTooltip + "<br/><?php print $langs->transnoentities('Product'); ?> : " + data.match_on.product_info;

--- a/class/actions_discountrules.class.php
+++ b/class/actions_discountrules.class.php
@@ -161,7 +161,8 @@ class Actionsdiscountrules
 
 
 									discountTooltip = discountTooltip + "<br/><?php print $langs->transnoentities('Discount'); ?> : " +  data.reduction + "%"
-													 + "<br/><?php print $langs->transnoentities('FromQty'); ?> : " +   data.from_quantity;
+													 + "<br/><?php print $langs->transnoentities('FromQty'); ?> : " +   data.from_quantity
+													 + "<br/><?php print $langs->transnoentities('ThirdPartyType'); ?> : " +   data.typentlabel;
 
 									if(data.fk_product > 0) {
 										discountTooltip = discountTooltip + "<br/><?php print $langs->transnoentities('Product'); ?> : " + data.match_on.product_info;

--- a/class/actions_discountrules.class.php
+++ b/class/actions_discountrules.class.php
@@ -187,9 +187,9 @@ class Actionsdiscountrules
 									$inputPriceHt.val(data.subprice);
 									$inputPriceHt.addClass("discount-rule-change --info");
                                     discountTooltip = discountTooltip + data.label
-                                        + "<br/><?php print $langs->transnoentities('Price'); ?> : " +  data.subprice + "%"
+                                        + "<br/><?php print $langs->transnoentities('Price'); ?> : " +  data.subprice
                                         + "<br/><?php print $langs->transnoentities('Discount'); ?> : " +  data.reduction + "%"
-                                        + "<br/><?php print $langs->transnoentities('Date'); ?> : " +   data.date_valid_human
+                                        + "<br/><?php print $langs->transnoentities('Date'); ?> : " +   data.date_object_human
                                         + "<br/><?php print $langs->transnoentities('Qty'); ?> : " +   data.qty
                                     ;
                                 }

--- a/class/discountrule.class.php
+++ b/class/discountrule.class.php
@@ -80,6 +80,7 @@ class DiscountRule extends CommonObject
 
     public $fk_country;
     public $fk_company;
+	public $fk_c_typent;
 
     public $fk_product;
 	/** @var Product $product */
@@ -248,6 +249,18 @@ class DiscountRule extends CommonObject
 			'visible' => 1,
 			'enabled' => 1,
 			'position' => 90,
+			'nullvalue'=>0,
+			'default'=>0,
+			'index' => 1,
+			//'help' => 'CustomerHelp'
+		),
+
+		'fk_c_typent' =>array(
+			'type' => 'integer',
+			'label' => 'ThirdPartyType',
+			'visible' => 1,
+			'enabled' => 1,
+			'position' => 91,
 			'nullvalue'=>0,
 			'default'=>0,
 			'index' => 1,
@@ -1413,7 +1426,7 @@ class DiscountRule extends CommonObject
 	 */
 	public function showInputField($val, $key, $value, $moreparam = '', $keysuffix = '', $keyprefix = '', $morecss = 0, $nonewbutton = 0)
 	{
-		global $conf, $langs, $form;
+		global $conf, $langs, $form, $user;
 
 		if ($conf->categorie->enabled) {
 			include_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
@@ -1428,6 +1441,13 @@ class DiscountRule extends CommonObject
 
 		if ($key == 'fk_country'){
 			$out = $form->select_country($value, $keyprefix.$key.$keysuffix);
+		}
+		elseif ($key == 'fk_c_typent'){
+			require_once DOL_DOCUMENT_ROOT.'/core/class/html.formcompany.class.php';
+			$formcompany = new FormCompany($this->db);
+			$sortparam = (empty($conf->global->SOCIETE_SORT_ON_TYPEENT) ? 'ASC' : $conf->global->SOCIETE_SORT_ON_TYPEENT); // NONE means we keep sort of original array, so we sort on position. ASC, means next function will sort on label.
+			$out = $form->selectarray("fk_c_typent", $formcompany->typent_array(0), $this->fk_c_typent, 0, 0, 0, '', 0, 0, 0, $sortparam);
+			if ($user->admin) $out.=' '.info_admin($langs->trans("YouCanChangeValuesForThisListFromDictionarySetup"), 1);
 		}
 		elseif ($key == 'all_category_product'){
 			// Petite astuce car je ne peux pas creer de input pour les categories donc je les ajoutent là
@@ -1514,6 +1534,14 @@ class DiscountRule extends CommonObject
 		elseif ($key == 'all_category_company'){
 			// Petite astuce car je ne peux pas creer de input pour les categories donc je les ajoutent là
 			$out = $this->getCategorieBadgesList($this->TCategoryCompany, $langs->trans('AllCustomersCategories'));
+		}
+		elseif ($key == 'fk_c_typent'){
+			require_once DOL_DOCUMENT_ROOT.'/core/class/html.formcompany.class.php';
+			$formcompany = new FormCompany($this->db);
+			$arr = $formcompany->typent_array();
+			if(isset($arr[$this->fk_c_typent])){
+				$out = $arr[$this->fk_c_typent];
+			}
 		}
 		elseif ($key == 'fk_status'){
 			$out =  $this->getLibStatut(5); // to fix dolibarr using 3 instead of 2

--- a/class/discountrule.class.php
+++ b/class/discountrule.class.php
@@ -851,6 +851,25 @@ class DiscountRule extends CommonObject
 	    
 	}
 
+	static public function getAllConnectedCats($TCat){
+		$TAllCat = array();
+		foreach ($TCat as $cat) {
+			$TAllCat[] = $cat;
+
+			// SEARCH AT PARENT
+			if(!empty($cat)){ // To avoid strange behavior
+				$parents = DiscountRule::getCategoryParent($cat);
+				if (!empty($parents)) {
+					foreach ($parents as $parentCat) {
+						$TAllCat[] = $parentCat;
+					}
+				}
+			}
+		}
+
+		return array_unique($TAllCat);
+	}
+
 	/**
 	 * @param string $col database col
 	 * @param string $val value to search

--- a/class/discountrule.class.php
+++ b/class/discountrule.class.php
@@ -1366,28 +1366,35 @@ class DiscountRule extends CommonObject
         $fk_product = intval($fk_product);
         $fk_company = intval($fk_company);
 
+        $dateDocCol = '';
+
         if($element === 'facture'){
             $table          = 'facture';
             $tableDet       = 'facturedet';
             $fkObjectCol    = 'fk_facture';
+			$dateDocCol		= 'datef';
             if(intval(DOL_VERSION) < 10) $refCol = 'facnumber';
         }
         elseif($element === 'commande'){
             $table          = 'commande';
             $tableDet       = 'commandedet';
             $fkObjectCol    = 'fk_commande';
+			$dateDocCol		= 'date_commande';
         }
         elseif($element === 'propal'){
             $table          = 'propal';
             $tableDet       = 'propaldet';
             $fkObjectCol    = 'fk_propal';
+			$dateDocCol		= 'datep';
         }
 
-        if(empty($table)){
+        if(empty($table) || empty($dateDocCol)){
             return false;
         }
 
-        $sql = 'SELECT line.remise_percent, object.rowid, object.'.$refCol.' as ref, object.date_valid, object.entity, line.qty, line.subprice ' ;
+        $sql = 'SELECT line.remise_percent, object.rowid, object.'.$refCol.' as ref, object.entity, line.qty, line.subprice ' ;
+
+		$sql.= ', '.$dateDocCol.' as date_object ';
 
         $sql.= ' FROM '.MAIN_DB_PREFIX.$tableDet.' line ';
         $sql.= ' JOIN '.MAIN_DB_PREFIX.$table.' object ON ( line.'.$fkObjectCol.' = object.rowid ) ';
@@ -1402,7 +1409,7 @@ class DiscountRule extends CommonObject
         }
 
         if(!empty($conf->global->DISCOUNTRULES_SEARCH_DAYS)){
-            $sql.= ' AND object.date_valid >= CURDATE() - INTERVAL '.abs(intval($conf->global->DISCOUNTRULES_SEARCH_DAYS)).' DAY ';
+            $sql.= ' AND object.'.$dateDocCol.' >= CURDATE() - INTERVAL '.abs(intval($conf->global->DISCOUNTRULES_SEARCH_DAYS)).' DAY ';
         }
 
         $sql.= ' ORDER BY line.remise_percent DESC ';
@@ -1415,7 +1422,7 @@ class DiscountRule extends CommonObject
         {
             if ($obj = $db->fetch_object($res))
             {
-                $obj->date_valid = $db->jdate($obj->date_valid);
+                $obj->date_object = $db->jdate($obj->date_object);
                 $obj->element = $element;
                 return $obj;
             }

--- a/class/discountrule.class.php
+++ b/class/discountrule.class.php
@@ -29,7 +29,7 @@
 require_once DOL_DOCUMENT_ROOT . '/core/class/commonobject.class.php';
 require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
 require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
-
+require_once __DIR__ . '/../lib/discountrules.lib.php';
 
 /**
  * Class for discountrule
@@ -1382,7 +1382,6 @@ class DiscountRule extends CommonObject
             $sql.= ' AND line.qty = '.$from_quantity;
         }
 
-
         if(!empty($conf->global->DISCOUNTRULES_SEARCH_DAYS)){
             $sql.= ' AND object.date_valid >= CURDATE() - INTERVAL '.abs(intval($conf->global->DISCOUNTRULES_SEARCH_DAYS)).' DAY ';
         }
@@ -1446,7 +1445,9 @@ class DiscountRule extends CommonObject
 			require_once DOL_DOCUMENT_ROOT.'/core/class/html.formcompany.class.php';
 			$formcompany = new FormCompany($this->db);
 			$sortparam = (empty($conf->global->SOCIETE_SORT_ON_TYPEENT) ? 'ASC' : $conf->global->SOCIETE_SORT_ON_TYPEENT); // NONE means we keep sort of original array, so we sort on position. ASC, means next function will sort on label.
-			$out = $form->selectarray("fk_c_typent", $formcompany->typent_array(0), $this->fk_c_typent, 0, 0, 0, '', 0, 0, 0, $sortparam);
+			$TTypent = $formcompany->typent_array(0);
+			//$TTypent[0] = $langs->trans('AllTypeEnt');
+			$out = $form->selectarray("fk_c_typent", $TTypent, $this->fk_c_typent, 0, 0, 0, '', 0, 0, 0, $sortparam);
 			if ($user->admin) $out.=' '.info_admin($langs->trans("YouCanChangeValuesForThisListFromDictionarySetup"), 1);
 		}
 		elseif ($key == 'all_category_product'){
@@ -1536,12 +1537,8 @@ class DiscountRule extends CommonObject
 			$out = $this->getCategorieBadgesList($this->TCategoryCompany, $langs->trans('AllCustomersCategories'));
 		}
 		elseif ($key == 'fk_c_typent'){
-			require_once DOL_DOCUMENT_ROOT.'/core/class/html.formcompany.class.php';
-			$formcompany = new FormCompany($this->db);
-			$arr = $formcompany->typent_array();
-			if(isset($arr[$this->fk_c_typent])){
-				$out = $arr[$this->fk_c_typent];
-			}
+			$out = getTypeEntLabel($this->fk_c_typent);
+			if(!$out){ $out = ''; }
 		}
 		elseif ($key == 'fk_status'){
 			$out =  $this->getLibStatut(5); // to fix dolibarr using 3 instead of 2

--- a/core/modules/moddiscountrules.class.php
+++ b/core/modules/moddiscountrules.class.php
@@ -72,7 +72,7 @@ class moddiscountrules extends DolibarrModules
 		$this->editor_url = 'https://www.atm-consulting.fr';
 
 		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated' or a version string like 'x.y.z'
-		$this->version = '2.0.0';
+		$this->version = '2.1.0';
 		// Key used in llx_const table to save module status enabled/disabled (where discountrules is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Name of image file used for this module.

--- a/langs/fr_FR/discountrules.lang
+++ b/langs/fr_FR/discountrules.lang
@@ -114,3 +114,4 @@ ErrorOneOffThisFieldsAreRequired = Vous devez définir au moins un de ces champs
 ReductionAmount = Montant de remise fixe
 InfosProduct = Informations produit
 ProductPrice = Prix produit
+AllTypeEnt = Tous les types

--- a/lib/discountrules.lib.php
+++ b/lib/discountrules.lib.php
@@ -138,3 +138,28 @@ function discountRulesBannerTab(DiscountRule $object, $showNav = 1){
 
 	dol_banner_tab($object, 'id', $linkback, $showNav , 'rowid', 'label', $morehtmlref, '', 0, $morehtmlleft, $morehtmlstatus, 0, $morehtmlright);
 }
+
+/**
+ * TODO : cette maniere contre intuitive de récupérer le libellé est tiré de la card des tiers, j'ai préféré factoriser pour pouvoir facilement le modifier plus tard vu que j'aime pas le style...
+ * @param $fk_c_typent
+ * @return bool|mixed
+ */
+function getTypeEntLabel($fk_c_typent){
+	global $db, $langs;
+
+	if(empty($fk_c_typent)){
+		return $langs->trans("AllTypeEnt");
+	}
+
+	require_once DOL_DOCUMENT_ROOT.'/core/class/html.formcompany.class.php';
+
+	$fk_c_typent = intval($fk_c_typent);
+
+	$formcompany = new FormCompany($db);
+	$arr = $formcompany->typent_array();
+	if(isset($arr[$fk_c_typent])){
+		return $arr[$fk_c_typent];
+	}
+
+	return false;
+}

--- a/scripts/interface.php
+++ b/scripts/interface.php
@@ -14,6 +14,7 @@ if (!$res) die("Include of master fails");
 dol_include_once('discountrules/class/discountrule.class.php');
 require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
 require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
+require_once __DIR__ . '/../lib/discountrules.lib.php';
 
 // Load traductions files requiredby by page
 $langs->loadLangs(array("discountrules@discountrules", "other"));
@@ -199,6 +200,11 @@ if ($get === 'product-discount') {
 		$jsonResponse->reduction = $discount->reduction;
 		$jsonResponse->entity = $discount->entity;
 		$jsonResponse->from_quantity = $discount->from_quantity;
+		$jsonResponse->fk_c_typent = $discount->fk_c_typent;
+
+		$jsonResponse->typentlabel  = getTypeEntLabel($discount->fk_c_typent);
+		if(!$jsonResponse->typentlabel ){ $jsonResponse->typentlabel = ''; }
+
 		$jsonResponse->fk_status = $discount->fk_status;
 		$jsonResponse->fk_product = $discount->fk_product;
 		$jsonResponse->date_creation = $discount->date_creation;

--- a/scripts/interface.php
+++ b/scripts/interface.php
@@ -17,7 +17,7 @@ require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
 require_once __DIR__ . '/../lib/discountrules.lib.php';
 
 // Load traductions files requiredby by page
-$langs->loadLangs(array("discountrules@discountrules", "other"));
+$langs->loadLangs(array("discountrules@discountrules", "other", 'main'));
 
 
 $get = GETPOST('get');
@@ -143,13 +143,13 @@ if ($get === 'product-discount') {
 				$jsonResponse->id = $documentDiscount->rowid;
 				$jsonResponse->label = $documentDiscount->ref;
 				$jsonResponse->qty = $documentDiscount->qty;
-				$jsonResponse->subprice = $jsonResponse->product_price =  $documentDiscount->subprice;
+				$jsonResponse->subprice = $jsonResponse->product_price =  doubleval($documentDiscount->subprice);
 				$jsonResponse->product_reduction_amount = 0;
 				$jsonResponse->reduction = $documentDiscount->remise_percent;
 				$jsonResponse->entity = $documentDiscount->entity;
 				$jsonResponse->fk_status = $documentDiscount->fk_status;
-				$jsonResponse->date_valid = $documentDiscount->date_valid;
-				$jsonResponse->date_valid_human = dol_print_date($documentDiscount->date_valid, '%d %b %Y');
+				$jsonResponse->date_object = $documentDiscount->date_object;
+				$jsonResponse->date_object_human = dol_print_date($documentDiscount->date_object, '%d %b %Y');
 			}
 		}
 	}

--- a/scripts/interface.php
+++ b/scripts/interface.php
@@ -198,6 +198,7 @@ if ($get === 'product-discount') {
 		$jsonResponse->product_reduction_amount = $discount->product_reduction_amount;
 		$jsonResponse->reduction = $discount->reduction;
 		$jsonResponse->entity = $discount->entity;
+		$jsonResponse->from_quantity = $discount->from_quantity;
 		$jsonResponse->fk_status = $discount->fk_status;
 		$jsonResponse->fk_product = $discount->fk_product;
 		$jsonResponse->date_creation = $discount->date_creation;

--- a/sql/update_2.0.0-2.1.0.sql
+++ b/sql/update_2.0.0-2.1.0.sql
@@ -1,0 +1,17 @@
+-- Copyright (C) 2018 John BOTELLA
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+ALTER TABLE llx_discountrule ADD fk_c_typent int(11) NOT NULL DEFAULT '0';


### PR DESCRIPTION
Need https://github.com/ATM-Consulting/dolibarr_module_discountrules/pull/3

Un peu de factorisation et surtout j'ai retiré une partie du script qui ne servait plus à rien depuis la V2 avec la modification de la méthode fetchByCrit.

Le script devrait être maintenant plus simple à lire.

Il faut effectuer une batterie de tests avant de merger cette PR car je n'ai testé qu'une partie des cas.