### PR TITLE
New/2.0 update rules from proposal lines

### DIFF
--- a/class/actions_discountrules.class.php
+++ b/class/actions_discountrules.class.php
@@ -729,9 +729,11 @@ class Actionsdiscountrules
 							$('input[id^="updateDiscountRule"]').prop('checked', $('#selectall').prop('checked'));
 						});
 						$('#statut').change(function () {
-							parseInt($('#statut').val()) !== <?php echo Propal::STATUS_SIGNED ?>
-							&& $('table#selectDiscounts').hide()
-							|| $('table#selectDiscounts').show();
+							if (parseInt($('#statut').val()) !== <?php echo Propal::STATUS_SIGNED ?>) {
+								$('table#selectDiscounts').hide()
+							} else {
+								$('table#selectDiscounts').show();
+							}
 							$('#dialog-confirm').dialog({
 								width: 'auto',
 								height: 'auto',

--- a/class/actions_discountrules.class.php
+++ b/class/actions_discountrules.class.php
@@ -132,7 +132,7 @@ class Actionsdiscountrules
 				// printCommonFooter(), puis la valeur de ce champ est réinterceptée ici.
 				$action = 'statut_override';
 			} elseif ($action == 'setstatut'
-					  && GETPOST('statut', 'int') == 2
+					  && GETPOST('statut', 'int') == Propal::STATUS_SIGNED
 					  && GETPOSTISSET('updateDiscountRule')
 			) {
 				dol_include_once('/discountrules/class/discountrule.class.php');

--- a/class/actions_discountrules.class.php
+++ b/class/actions_discountrules.class.php
@@ -131,8 +131,7 @@ class Actionsdiscountrules
 			}
 		}
 
-		if (array_intersect(array('propalcard', 'ordercard', 'facturecard'), $context)) {
-			$form = new Form($this->db);
+		if (array_intersect(array('propalcard', 'ordercard', 'invoicecard'), $context)) {
 			$confirm = GETPOST('confirm', 'alpha');
 			dol_include_once('/discountrules/class/discountrule.class.php');
 			include_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
@@ -155,10 +154,13 @@ class Actionsdiscountrules
 				$c = new Categorie($this->db);
 				$client = new Societe($this->db);
 				$client->fetch($object->socid);
-				$TProductCat = DiscountRule::getAllConnectedCats($c->containing($line->fk_product, Categorie::TYPE_PRODUCT, 'id'));
-				$TCompanyCat = DiscountRule::getAllConnectedCats($c->containing($object->socid, Categorie::TYPE_CUSTOMER, 'id'));
+				$TCompanyCat = $c->containing($object->socid, Categorie::TYPE_CUSTOMER, 'id');
+				$TCompanyCat = DiscountRule::getAllConnectedCats($TCompanyCat);
 				foreach ($object->lines as $line) {
 					/** @var PropaleLigne|OrderLine|FactureLigne $line */
+
+					$TProductCat = $c->containing($line->fk_product, Categorie::TYPE_PRODUCT, 'id');
+					$TProductCat = DiscountRule::getAllConnectedCats($TProductCat);
 
 					// fetchByCrit = cherche la meilleure remise qui corresponde aux contraintes spécifiées
 					$res = $discountrule->fetchByCrit(

--- a/class/actions_discountrules.class.php
+++ b/class/actions_discountrules.class.php
@@ -104,7 +104,6 @@ class Actionsdiscountrules
 						
 						var idprod = $('#idprod').val();
 						var qty = $('#qty').val();
-					
 						if(idprod != lastidprod || qty != lastqty)
 						{
 
@@ -121,8 +120,8 @@ class Actionsdiscountrules
 									    'fk_product': idprod,
 								    	'get': "product-discount",
 								    	'qty': qty,
-								    	'fk_company': '<?php print $object->socid; ?>',
-									    'fk_project' : '<?php print $object->fk_project; ?>',
+								    	'fk_company': '<?php print intval($object->socid); ?>',
+									    'fk_project' : '<?php print intval($object->fk_project); ?>',
 								  		}
 							})
 							.done(function( data ) {

--- a/class/actions_discountrules.class.php
+++ b/class/actions_discountrules.class.php
@@ -607,66 +607,65 @@ class Actionsdiscountrules
 					array('type' => 'text', 'name' => 'note_private', 'label' => $langs->trans("Note"),'value' => '')				// Field to complete private note (not replace)
 			);
 
-			if (! empty($conf->notification->enabled))
-			{
+			if (! empty($conf->notification->enabled)) {
 				require_once DOL_DOCUMENT_ROOT . '/core/class/notify.class.php';
 				$error = 0;
 				$notify = new Notify($db);
 				$formquestion = array_merge($formquestion, array(
 						array('type' => 'onecolumn', 'value' => $notify->confirmMessage('PROPAL_CLOSE_SIGNED', $object->socid, $object)),
 				));
-
-				/* Code spécifique DiscountRules */
-				// séparateur horizontal
-				$subTableLines = array();
-				$inputok = array( // noms des inputs et des checkboxes qui seront ajoutés à l’URL par le bouton OK
-						'statut',
-						'note_private',
-				);
-				$product = new Product($db);
-				$willBeCreatedMsg = '<span title="'
-									. dol_escape_htmltag($langs->trans('RuleWillBeCreatedTooltip')) . '">'
-									. $langs->trans('RuleWillBeCreated')
-									. '</span>';
-				/** @var CommonObjectLine $line */
-				foreach ($object->lines as $line) {
-					$matchingRule = $this->_findDiscountRuleMatchingLine($object, $line);
-					if ($matchingRule === null) {
-						$error++;
-					}
-					if (empty($line->remise_percent)) continue;
-					if (empty($line->fk_product)) continue;
-					if ($product->fetch($line->fk_product) <= 0) continue;
-					$checkboxName = 'updateDiscountRule[' . intval($line->id) . ']';
-					$checkboxId = 'updateDiscountRule_' . intval($line->id);
-					$inputok[] = $checkboxId;
-					$remise_percent = price($line->remise_percent) . ' %';
-					if ($line->remise_percent == 100)  $remise_percent = $langs->trans('Offered');
-					$subTableLines[] = '<tr>'
-									   . '<td>' . ($matchingRule->id ? $matchingRule->getNomUrl() : $willBeCreatedMsg) . '</td>'
-									   . '<td>' . $product->getNomUrl() . ' – ' . $product->label . '</td>'
-//									   . '<td>' . $line->qty . '</td>'
-									   . '<td class="right" style="padding-right: 2em">'
-									   . '<b>' . $remise_percent . '</b>'
-									   . '</td>'
-									   . '<td>'
-									   . '<input type="checkbox" id="' . $checkboxId . '" name="' . $checkboxName . '" />'
-									   . '</td>'
-									   . '</tr>';
-				}
-				$subTable = '<hr/><table id="selectDiscounts" class="discount-rule-selection-table" style="display: none; max-width: 1200px"><thead>'
-						. '<tr>'
-							. '<th style="max-width: 10em;">' . $langs->trans('CreateOrUpdateRule') . '</th>'
-							. '<th>' . $form->textwithtooltip($langs->trans('SelectDiscountsToTurnIntoRules'), $langs->trans('SelectDiscountsToTurnIntoRulesTooltip'), 2,1,img_help(1,'')) . '</th>'
-//							. '<th>' . $langs->trans('Qty') . '</th>'
-							. '<th>' . $langs->trans('Discount') . '</th>'
-							. '<th>' . '<input type="checkbox" id="selectall" name="selectall" title="' . $langs->trans('ToggleSelectAll') . '" />' . '</th>'
-							. '</tr>'
-							. '</thead><tbody>'
-							. join('', $subTableLines)
-							. '</tbody></table>';
-				$formquestion[] = array('type' => 'onecolumn', 'value' => $subTable);
 			}
+
+			/* Code spécifique DiscountRules */
+			// séparateur horizontal
+			$subTableLines = array();
+			$inputok = array( // noms des inputs et des checkboxes qui seront ajoutés à l’URL par le bouton OK
+					'statut',
+					'note_private',
+			);
+			$product = new Product($db);
+			$willBeCreatedMsg = '<span title="'
+								. dol_escape_htmltag($langs->trans('RuleWillBeCreatedTooltip')) . '">'
+								. $langs->trans('RuleWillBeCreated')
+								. '</span>';
+			/** @var CommonObjectLine $line */
+			foreach ($object->lines as $line) {
+				$matchingRule = $this->_findDiscountRuleMatchingLine($object, $line);
+				if ($matchingRule === null) {
+					$error++;
+				}
+				if (empty($line->remise_percent)) continue;
+				if (empty($line->fk_product)) continue;
+				if ($product->fetch($line->fk_product) <= 0) continue;
+				$checkboxName = 'updateDiscountRule[' . intval($line->id) . ']';
+				$checkboxId = 'updateDiscountRule_' . intval($line->id);
+				$inputok[] = $checkboxId;
+				$remise_percent = price($line->remise_percent) . ' %';
+				if ($line->remise_percent == 100)  $remise_percent = $langs->trans('Offered');
+				$subTableLines[] = '<tr>'
+								   . '<td>' . ($matchingRule->id ? $matchingRule->getNomUrl() : $willBeCreatedMsg) . '</td>'
+								   . '<td>' . $product->getNomUrl() . ' – ' . $product->label . '</td>'
+//									   . '<td>' . $line->qty . '</td>'
+								   . '<td class="right" style="padding-right: 2em">'
+								   . '<b>' . $remise_percent . '</b>'
+								   . '</td>'
+								   . '<td>'
+								   . '<input type="checkbox" id="' . $checkboxId . '" name="' . $checkboxName . '" />'
+								   . '</td>'
+								   . '</tr>';
+			}
+			$subTable = '<hr/><table id="selectDiscounts" class="discount-rule-selection-table" style="display: none; max-width: 1200px"><thead>'
+					. '<tr>'
+						. '<th style="max-width: 10em;">' . $langs->trans('CreateOrUpdateRule') . '</th>'
+						. '<th>' . $form->textwithtooltip($langs->trans('SelectDiscountsToTurnIntoRules'), $langs->trans('SelectDiscountsToTurnIntoRulesTooltip'), 2,1,img_help(1,'')) . '</th>'
+//							. '<th>' . $langs->trans('Qty') . '</th>'
+						. '<th>' . $langs->trans('Discount') . '</th>'
+						. '<th>' . '<input type="checkbox" id="selectall" name="selectall" title="' . $langs->trans('ToggleSelectAll') . '" />' . '</th>'
+						. '</tr>'
+						. '</thead><tbody>'
+						. implode('', $subTableLines)
+						. '</tbody></table>';
+			$formquestion[] = array('type' => 'onecolumn', 'value' => $subTable);
 
 			$formconfirmURL = $_SERVER["PHP_SELF"] . '?id=' . $object->id;
 			$formconfirmURL_yes = $formconfirmURL . '&action=setstatut&confirm=yes';
@@ -684,12 +683,12 @@ class Actionsdiscountrules
 
 			?>
 				<script type="application/javascript">
-					$(() => {
+					$(function () {
 						let jsVars = <?php echo json_encode($jsVars); ?>;
 						let $dialog = $('#dialog-confirm');
 						let overrideDialogActions = function() {
 							let dialogButtons = $dialog.dialog('option', 'buttons');
-							dialogButtons[jsVars.trans['Yes']] = () => {
+							dialogButtons[jsVars.trans['Yes']] = function () {
 								/*
 								Ceci est une copie modifiée du callback standard qui est dans html.form > formconfirm;
 								seule l'action "Yes" du dialogue est surchargée pour que soient pris en compte les
@@ -718,7 +717,7 @@ class Actionsdiscountrules
 							}
 							$dialog.dialog('option', 'buttons', dialogButtons);
 						};
-						window.setTimeout(() => {
+						window.setTimeout(function () {
 							if ($dialog.hasClass('ui-dialog-content')) {
 								overrideDialogActions();
 							} else {
@@ -726,10 +725,10 @@ class Actionsdiscountrules
 							}
 						}, 0);
 						// setTimeout(overrideDialogActions, 500); // TODO C'EST ULTRA MOCHE
-						$('#selectall').change(() => {
+						$('#selectall').change(function () {
 							$('input[id^="updateDiscountRule"]').prop('checked', $('#selectall').prop('checked'));
 						});
-						$('#statut').change(() => {
+						$('#statut').change(function () {
 							parseInt($('#statut').val()) !== <?php echo Propal::STATUS_SIGNED ?>
 							&& $('table#selectDiscounts').hide()
 							|| $('table#selectDiscounts').show();

--- a/class/actions_discountrules.class.php
+++ b/class/actions_discountrules.class.php
@@ -173,7 +173,7 @@ class Actionsdiscountrules
 							$error++;
 							continue;
 						}
-						$discountrule->label = $product->ref . '_' . ($projectId ? ('proj_' . $projectId) : ('cust_' . $customerId));
+						$discountrule->label = $product->ref . '_' . ('cust_' . $customerId) . ($projectId ? ('_proj_' . $projectId) : '');
 					}
 					$discountrule->reduction = $discountPercent;
 
@@ -796,6 +796,8 @@ class Actionsdiscountrules
 
 		if (!empty($object->fk_project)) {
 			$criteria[] = 'rule.fk_project = ' . intval($object->fk_project);
+		} else {
+			$criteria[] = '(rule.fk_project = 0)';
 		}
 
 		$sql =

--- a/class/discountrule.class.php
+++ b/class/discountrule.class.php
@@ -30,7 +30,7 @@ require_once DOL_DOCUMENT_ROOT . '/core/class/commonobject.class.php';
 require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
 require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
 require_once __DIR__ . '/../lib/discountrules.lib.php';
-require __DIR__ . '/discountruletools.class.php';
+require_once __DIR__ . '/discountruletools.class.php';
 
 /**
  * Class for discountrule

--- a/class/discountrule.class.php
+++ b/class/discountrule.class.php
@@ -30,6 +30,7 @@ require_once DOL_DOCUMENT_ROOT . '/core/class/commonobject.class.php';
 require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
 require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
 require_once __DIR__ . '/../lib/discountrules.lib.php';
+require __DIR__ . '/discountruletools.class.php';
 
 /**
  * Class for discountrule
@@ -1004,6 +1005,7 @@ class DiscountRule extends CommonObject
 	 * @param int $fk_c_typent
 	 * @param int $fk_project
 	 * @return int <0 if KO, 0 if not found, > 0 if OK
+	 * @see $this->lastFetchByCritResult: last fetched database object 
 	 */
 	public function fetchByCrit($from_quantity = 1, $fk_product = 0, $fk_category_product = 0, $fk_category_company = 0, $fk_company = 0, $date = 0, $fk_country = 0, $fk_c_typent = 0, $fk_project = 0)
 	{

--- a/class/discountrule.class.php
+++ b/class/discountrule.class.php
@@ -1014,7 +1014,7 @@ class DiscountRule extends CommonObject
 		$product = $this->getProductCache($fk_product);
 
 	    $baseSubprice = 0;
-	    if(!empty($product) && empty($fk_category_product)){
+	    if(!empty($product)){
 
 	    	// Dans le cas d'une règle liée à un produit, c'est le prix net qui sert de base de comparaison
 
@@ -1047,11 +1047,8 @@ class DiscountRule extends CommonObject
 		$sql.= self::prepareSearch('fk_company', $fk_company);
 		$sql.= self::prepareSearch('fk_project', $fk_project);
 
-		if(empty($fk_category_product) && !empty($fk_product)){
-			$sql.= self::prepareSearch('fk_product', $fk_product);
-		}else{
-			$sql.= ' AND fk_product = 0 ' ;
-		}
+		$sql.= self::prepareSearch('fk_product', $fk_product);
+
 
 	    $this->lastFetchByCritResult = false;
 

--- a/class/discountruletools.class.php
+++ b/class/discountruletools.class.php
@@ -5,7 +5,7 @@
  *
  * Class DiscountRuleTools
  */
-class discountruletools
+class DiscountRuleTools
 {
 	/**
 	 * Helper method: calls $object->updateline() with the right parameters

--- a/class/discountruletools.class.php
+++ b/class/discountruletools.class.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Collection of tools not directly related to DiscountRule
+ *
+ * Class DiscountRuleTools
+ */
+class discountruletools
+{
+	/**
+	 * Helper method: calls $object->updateline() with the right parameters
+	 * depending on the object's type (proposal, order or invoice).
+	 * TODO: check compatibility with multicurrency
+	 *
+	 * @param CommonObject $object
+	 * @param CommonObjectLine $line
+	 * @param int $notrigger
+	 * @return int > 0 = success; < 0 = failure
+	 */
+	static public function updateLineBySelf($object, $line, $notrigger=0)
+	{
+		if(empty($line->array_options)){
+			$line->fetch_optionals();
+		}
+
+		$line->subprice_ht_devise = 0;
+
+		if($object->element === 'propal'){
+			/** @var Propal $object */
+			return $object->updateline($line->id, $line->subprice, $line->qty, $line->remise_percent, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, $line->desc, 'HT', $line->info_bits, $line->special_code, $line->fk_parent_line, 0, $line->fk_fournprice, $line->pa_ht, $line->product_label, $object->product_type, $line->date_start, $line->date_end, $line->array_options, $line->fk_unit, $line->subprice_ht_devise, $notrigger);
+		}
+		elseif($object->element === 'facture' ){
+			/** @var Facture $object */
+			return $object->updateline($line->id, $line->desc, $line->subprice, $line->qty, $line->remise_percent, $line->date_start, $line->date_end, $line->tva_tx, $line->localtax1_tx, $line->localtax2_tx, 'HT', $line->info_bits, $object->product_type, $line->fk_parent_line, $line->skip_update_total, $line->fk_fournprice, $line->pa_ht, $line->label, $line->special_code, $line->array_options, $line->situation_percent, $line->fk_unit, $line->subprice_ht_devise, $notrigger);
+		}
+		elseif($object->element === 'commande' ){
+			/** @var Commande $object */
+			return $object->updateline($line->id, $line->desc, $line->subprice, $line->qty, $line->remise_percent, $line->tva_tx, $line->localtax1_tx,$line->localtax2_tx, 'HT', $line->info_bits, $line->date_start, $line->date_end, $object->product_type, $line->fk_parent_line, $line->skip_update_total, $line->fk_fournprice, $line->pa_ht, $line->label, $line->special_code, $line->array_options, $line->fk_unit, $line->subprice_ht_devise, $notrigger);
+		}
+
+		return -1;
+
+	}
+}

--- a/css/discountrules.css.php
+++ b/css/discountrules.css.php
@@ -79,3 +79,32 @@ else header('Cache-Control: no-cache');
 .discount-rule-change.--warning, input.flat.discount-rule-change.--warning, input.discount-rule-change.--warning{
 	outline: 1px solid rgba(255, 0, 205, 0.39);
 }
+
+.discount-rule-selection-table{
+	border-collapse: collapse;
+}
+
+
+
+<?php
+$colorbacktitle1     =empty($user->conf->THEME_ELDY_ENABLE_PERSONALIZED)?(empty($conf->global->THEME_ELDY_BACKTITLE1)   ?$colorbacktitle1:$conf->global->THEME_ELDY_BACKTITLE1)      :(empty($user->conf->THEME_ELDY_BACKTITLE1)?$colorbacktitle1:$user->conf->THEME_ELDY_BACKTITLE1);
+$useboldtitle=(isset($conf->global->THEME_ELDY_USEBOLDTITLE)?$conf->global->THEME_ELDY_USEBOLDTITLE:0);
+$colortexttitle      =empty($user->conf->THEME_ELDY_ENABLE_PERSONALIZED)?(empty($conf->global->THEME_ELDY_TEXTTITLE)    ?$colortext:$conf->global->THEME_ELDY_TEXTTITLE)             :(empty($user->conf->THEME_ELDY_TEXTTITLE)?$colortexttitle:$user->conf->THEME_ELDY_TEXTTITLE);
+$fontlist='roboto,arial,tahoma,verdana,helvetica';    //$fontlist='verdana,helvetica,arial,sans-serif';
+global $langs;
+$left=($langs->trans("DIRECTION")=='rtl'?'right':'left');
+?>
+.discount-rule-selection-table th{
+	background: rgb(<?php echo $colorbacktitle1; ?>);
+	font-weight: <?php echo $useboldtitle?'bold':'normal'; ?>;
+	border-bottom: 1px solid #FDFFFF;
+
+	color: rgb(<?php echo $colortexttitle; ?>);
+	font-family: <?php print $fontlist ?>;
+	text-align: <?php echo $left; ?>;
+}
+
+.discount-rule-selection-table td, .discount-rule-selection-table th{
+	padding: 6px 6px 2px 6px;
+	border: solid 1px rgb(<?php echo preg_replace_callback('/(\\d+)/', function($m) { return max(0, intval(0.6 * $m[0])); }, $colorbacktitle1); ?>);
+}

--- a/discountrule_list.php
+++ b/discountrule_list.php
@@ -441,6 +441,7 @@ if(!empty($fk_product)){
 $arrayofselected=is_array($toselect)?$toselect:array();
 
 $param='';
+if (!empty($fk_product)) $param .= '&fk_product=' . $fk_product;
 if (!empty($contextpage) && $contextpage != $_SERVER["PHP_SELF"]) $param .= '&contextpage='.urlencode($contextpage);
 if ($limit > 0 && $limit != $conf->liste_limit) $param .= '&limit='.urlencode($limit);
 foreach($search as $key => $val)
@@ -474,6 +475,7 @@ print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
 // print '<input type="hidden" name="token" value="'.newToken().'">'; // Dolibarr V12
 print '<input type="hidden" name="formfilteraction" id="formfilteraction" value="list">';
 print '<input type="hidden" name="action" value="list">';
+print '<input type="hidden" name="fk_product" value="'.$fk_product.'">';
 print '<input type="hidden" name="sortfield" value="'.$sortfield.'">';
 print '<input type="hidden" name="sortorder" value="'.$sortorder.'">';
 print '<input type="hidden" name="page" value="'.$page.'">';

--- a/langs/en_US/discountrules.lang
+++ b/langs/en_US/discountrules.lang
@@ -122,9 +122,13 @@ ExplainPriorityOfRuleApplied = Keep in mind that the rule that will be proposed 
 #
 # PROPOSAL CARD
 #
-#UpdateDiscountRulesFromLineDiscounts=Update this client's discount rules with this proposal's line discounts
 SelectDiscountsToTurnIntoRules=Select the lines the discount of which should be converted into a discount rule for that client
-ToggleSelectAll=(Un)Select all
+SelectDiscountsToTurnIntoRulesTooltip = Discount rules created or updated from this dialog will apply only to the selected product, client, project (if relevant), with no quantity criterion (if you need to create or edit blanket rules, go to Product > New Discount Rule).
+ToggleSelectAll = (Un)Select all
 confirmUpdateDiscountsTitle = Update prices?
-confirmUpdateDiscounts = Do you want to update line prices according to discount rules?
+confirmUpdateDiscounts = Update line prices according to discount rules?
 UpdateDiscountsFromRules = Apply discount rules
+CreateOrUpdateRule = Rule to be updated / new rule
+RuleWillBeCreated = New rule
+RuleWillBeCreatedTooltip = No existing rule found: if you check this box, the rule will be created on this product for this client and (if present) this project.
+RulesUpdated = Discount rules updated

--- a/langs/en_US/discountrules.lang
+++ b/langs/en_US/discountrules.lang
@@ -125,3 +125,6 @@ ExplainPriorityOfRuleApplied = Keep in mind that the rule that will be proposed 
 #UpdateDiscountRulesFromLineDiscounts=Update this client's discount rules with this proposal's line discounts
 SelectDiscountsToTurnIntoRules=Select the lines the discount of which should be converted into a discount rule for that client
 ToggleSelectAll=(Un)Select all
+confirmUpdateDiscountsTitle = Update prices?
+confirmUpdateDiscounts = Do you want to update line prices according to discount rules?
+UpdateDiscountsFromRules = Apply discount rules

--- a/langs/fr_FR/discountrules.lang
+++ b/langs/fr_FR/discountrules.lang
@@ -126,12 +126,13 @@ AvailableDiscountInfo = Infos sur la remise applicable
 #
 # PROPAL CARD
 #
-#UpdateDiscountRulesFromLineDiscounts = Mettre à jour les remises du client à partir des remises des lignes de la proposition
 SelectDiscountsToTurnIntoRules = Sélectionnez les remises à actualiser ou créer pour le client
+SelectDiscountsToTurnIntoRulesTooltip = Les remises créées ou actualisées seront applicables pour le produit indiqué, sans critère de quantité, et uniquement sur les propositions commerciales relatives au même client et (si défini) au même projet que la proposition courante. Si vous désirez créer des règles moins spécifiques, faites-le sur Produit > Nouvelle règle de prix.
 ToggleSelectAll = Tout (dé)sélectionner
 confirmUpdateDiscountsTitle = Mettre à jour les prix ?
 confirmUpdateDiscounts = Voulez-vous vraiment mettre à jour les prix des lignes en application des règles de remises ?
 UpdateDiscountsFromRules = Réappliquer les remises
 CreateOrUpdateRule = Règle existante à actualiser ou créer
 RuleWillBeCreated = Règle à créer
-RuleWillBeCreatedTooltip = Aucune règle applicable trouvée : si vous cochez cette ligne, la règle sera créée sur le produit pour le client et le projet courants.
+RuleWillBeCreatedTooltip = Aucune règle spécifique trouvée : si vous cochez cette ligne, la règle sera créée sur le produit pour le client et le projet courants.
+RulesUpdated = Règles mises à jour

--- a/langs/fr_FR/discountrules.lang
+++ b/langs/fr_FR/discountrules.lang
@@ -124,5 +124,5 @@ ActiveRuleProject = Règle de projet active
 # PROPAL CARD
 #
 #UpdateDiscountRulesFromLineDiscounts=Mettre à jour les remises du client à partir des remises des lignes de la proposition
-SelectDiscountsToTurnIntoRules=Si vous souhaitez mettre à jour les remises du client (et les créer si nécessaires), sélectionnez les lignes suivantes :
+SelectDiscountsToTurnIntoRules=Sélectionnez les remises à mettre à jour / à créer pour le client
 ToggleSelectAll=Tout (dé)sélectionner

--- a/langs/fr_FR/discountrules.lang
+++ b/langs/fr_FR/discountrules.lang
@@ -127,8 +127,11 @@ AvailableDiscountInfo = Infos sur la remise applicable
 # PROPAL CARD
 #
 #UpdateDiscountRulesFromLineDiscounts = Mettre à jour les remises du client à partir des remises des lignes de la proposition
-SelectDiscountsToTurnIntoRules = Sélectionnez les remises à mettre à jour / à créer pour le client
+SelectDiscountsToTurnIntoRules = Sélectionnez les remises à actualiser ou créer pour le client
 ToggleSelectAll = Tout (dé)sélectionner
 confirmUpdateDiscountsTitle = Mettre à jour les prix ?
 confirmUpdateDiscounts = Voulez-vous vraiment mettre à jour les prix des lignes en application des règles de remises ?
 UpdateDiscountsFromRules = Réappliquer les remises
+CreateOrUpdateRule = Règle existante à actualiser ou créer
+RuleWillBeCreated = Règle à créer
+RuleWillBeCreatedTooltip = Aucune règle applicable trouvée : si vous cochez cette ligne, la règle sera créée sur le produit pour le client et le projet courants.

--- a/langs/fr_FR/discountrules.lang
+++ b/langs/fr_FR/discountrules.lang
@@ -123,6 +123,9 @@ ActiveRuleProject = Règle de projet active
 #
 # PROPAL CARD
 #
-#UpdateDiscountRulesFromLineDiscounts=Mettre à jour les remises du client à partir des remises des lignes de la proposition
-SelectDiscountsToTurnIntoRules=Sélectionnez les remises à mettre à jour / à créer pour le client
-ToggleSelectAll=Tout (dé)sélectionner
+#UpdateDiscountRulesFromLineDiscounts = Mettre à jour les remises du client à partir des remises des lignes de la proposition
+SelectDiscountsToTurnIntoRules = Sélectionnez les remises à mettre à jour / à créer pour le client
+ToggleSelectAll = Tout (dé)sélectionner
+confirmUpdateDiscountsTitle = Mettre à jour les prix ?
+confirmUpdateDiscounts = Voulez-vous vraiment mettre à jour les prix des lignes en application des règles de remises ?
+UpdateDiscountsFromRules = Réappliquer les remises


### PR DESCRIPTION
# NEW
When the user sets a validated proposal as 'signed', the pop-in now allows them to select discount rules for update / creation (based on the lines' discounts). The created / updated rules are product-specific, client-specific and (when relevant) project-specific, but with no min quantity.

Additionally, on draft proposals, orders and invoices, a new button enables the user to re-apply relevant discount rules to all the document's lines in one go.

## Conseil aux relecteurs (si vous relisez en vue unifiée)
1) Utiliser l'option "whitespace" (pour ne pas se laisser polluer par les changements d'indentation)
2) Dans la console js du navigateur, coller ça pour avoir plus de confort de lecture :
```javascript
$('table.diff-table').setAttribute('data-tab-size', '4');
$('div.container-xl').style.maxWidth = 'none';
```