### PR TITLE
NEW update lines of documents with currently allowed discount rules

### DIFF
--- a/admin/setup.php
+++ b/admin/setup.php
@@ -104,13 +104,16 @@ _printInputFormPart('DISCOUNTRULES_SEARCH_DAYS', '', '', $metas);
 
 print '</table>';
 
-
-
-print load_fiche_titre($langs->trans("ParameterForDevelopmentOrDeprecated"), '', '');
-print '<div class="warning">'.$langs->trans("ParameterForDevelopmentOrDeprecatedHelp").'</div>';
-print '<table class="noborder" width="100%">';
-_printOnOff('DISCOUNTRULES_ALLOW_APPLY_DISCOUNT_TO_ALL_LINES');
-print '</table>';
+/**
+ * IN DEVELOPMENT
+ */
+if ($conf->global->MAIN_FEATURE_LEVEL >= 2) {
+	print load_fiche_titre($langs->trans("ParameterForDevelopmentOrDeprecated"), '', '');
+	print '<div class="warning">' . $langs->trans("ParameterForDevelopmentOrDeprecatedHelp") . '</div>';
+	print '<table class="noborder" width="100%">';
+	_printOnOff('DISCOUNTRULES_ALLOW_APPLY_DISCOUNT_TO_ALL_LINES');
+	print '</table>';
+}
 
 _updateBtn();
 

--- a/admin/setup.php
+++ b/admin/setup.php
@@ -77,9 +77,10 @@ dol_fiche_head(
 	$head,
 	'settings',
 	$langs->trans("ModulediscountrulesName"),
-	0,
+	-1,
 	"discountrules@discountrules"
 );
+dol_fiche_end(-1);
 
 
 $var=0;
@@ -100,6 +101,15 @@ _printOnOff('DISCOUNTRULES_SEARCH_QTY_EQUIV');
 $metas = array( 'type' => 'number', 'step' => '1', 'min' => 0 );
 _printInputFormPart('DISCOUNTRULES_SEARCH_DAYS', '', '', $metas);
 
+
+print '</table>';
+
+
+
+print load_fiche_titre($langs->trans("ParameterForDevelopmentOrDeprecated"), '', '');
+print '<div class="warning">'.$langs->trans("ParameterForDevelopmentOrDeprecatedHelp").'</div>';
+print '<table class="noborder" width="100%">';
+_printOnOff('DISCOUNTRULES_ALLOW_APPLY_DISCOUNT_TO_ALL_LINES');
 print '</table>';
 
 _updateBtn();
@@ -137,8 +147,7 @@ function _updateBtn()
 function _printOnOff($confkey, $title = false, $desc = '')
 {
     global $var, $bc, $langs;
-    $var=!$var;
-    print '<tr '.$bc[$var].'>';
+	print '<tr class="oddeven">';
     print '<td>'.($title?$title:$langs->trans($confkey));
     if (!empty($desc)) {
         print '<br><small>'.$langs->trans($desc).'</small>';

--- a/class/actions_discountrules.class.php
+++ b/class/actions_discountrules.class.php
@@ -285,6 +285,9 @@ class Actionsdiscountrules
 				$btnActionUrl = $_REQUEST['PHP_SELF'] . '?id=' . $object->id . '&action=askUpdateDiscounts&token=' . $_SESSION['newtoken'];
 				print dolGetButtonAction($langs->trans("UpdateDiscountsFromRules"),'','default',$btnActionUrl,'',$user->rights->discountrules->read && $updateDiscountBtnRight);
 			}
+
+
+			// ADD DISCOUNT RULES SEARCH ON DOCUMENT ADD LINE FORM
 			?>
 		    <!-- MODULE discountrules -->
 		    <link rel="stylesheet" type="text/css" href="<?php print dol_buildpath('discountrules/css/discountrules.css.php',1); ?>">

--- a/class/actions_discountrules.class.php
+++ b/class/actions_discountrules.class.php
@@ -63,6 +63,131 @@ class Actionsdiscountrules
 	    $this->db = $db;
 	}
 
+
+	/**
+	 * @param array $parameters
+	 * @param CommonObject $object
+	 * @param string $action
+	 * @param HookManager $hookmanager
+	 */
+	public function doActions($parameters, &$object, &$action, $hookmanager)
+	{
+		global $conf, $user, $langs;
+
+		$context = explode(':', $parameters['context']);
+		$langs->loadLangs(array('discountrules'));
+
+
+		// TODO : Fonctionnalité non complète à terminer et a mettre dans une methode
+		if (!empty($conf->global->DISCOUNTRULES_ALLOW_APPLY_DISCOUNT_TO_ALL_LINES)
+				&& array_intersect(array('propalcard', 'ordercard', 'invoicecard'), $context)
+		) {
+			$confirm = GETPOST('confirm', 'alpha');
+			dol_include_once('/discountrules/class/discountrule.class.php');
+			include_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
+			if ($action === 'askUpdateDiscounts') {
+
+				// Vérifier les droits avant d'agir
+				if(!self::checkUserUpdateObjectRight($user, $object)){
+					setEventMessage('NotEnoughtRights');
+					return -1;
+				}
+
+
+				global $delayedhtmlcontent;
+
+				$form = new Form($this->db);
+				$formconfirm = $form->formconfirm(
+						$_REQUEST['PHP_SELF'] . '?id=' . $object->id . '&token=' . $_SESSION['newtoken'],
+						$langs->trans('confirmUpdateDiscountsTitle'),
+						$langs->trans('confirmUpdateDiscounts'),
+						'doUpdateDiscounts',
+						array(), // inputs supplémentaires
+						'no', // choix présélectionné
+						2 // ajax ou non
+				);
+				$delayedhtmlcontent .= $formconfirm;
+			} elseif ($action === 'doUpdateDiscounts' && $confirm === 'yes') {
+
+				// Vérifier les droits avant d'agir
+				if(!self::checkUserUpdateObjectRight($user, $object)){
+					setEventMessage('NotEnoughtRights');
+					return -1;
+				}
+
+				$discountrule = new DiscountRule($this->db);
+				$c = new Categorie($this->db);
+				$client = new Societe($this->db);
+				$client->fetch($object->socid);
+				$TCompanyCat = $c->containing($object->socid, Categorie::TYPE_CUSTOMER, 'id');
+				$TCompanyCat = DiscountRule::getAllConnectedCats($TCompanyCat);
+				$updated = 0;
+				$updaterror = 0;
+				foreach ($object->lines as $line) {
+					/** @var PropaleLigne|OrderLine|FactureLigne $line */
+
+					$TProductCat = $c->containing($line->fk_product, Categorie::TYPE_PRODUCT, 'id');
+					$TProductCat = DiscountRule::getAllConnectedCats($TProductCat);
+
+					// fetchByCrit = cherche la meilleure remise qui corresponde aux contraintes spécifiées
+					$res = $discountrule->fetchByCrit(
+							$line->qty,
+							$line->fk_product,
+							$TProductCat,
+							$TCompanyCat,
+							$object->socid,
+							time(),
+							$client->country_id,
+							$client->typent_id,
+							$object->fk_project
+					);
+
+					// TODO : cette recherche de réduction est incomplète voir interface.php
+
+					if ($res > 0) {
+						$oldsubprice = $line->subprice;
+						$oldremise = $line->remise_percent;
+
+						// TODO : Appliquer aussi les tarifs comme pour interface.php sinon celà va créer des incohérances voir des abérations
+						$line->subprice = $discountrule->getProductSellPrice($line->fk_product, $object->socid) - $discountrule->product_reduction_amount;
+						// ne pas appliquer les prix à 0 (par contre, les remises de 100% sont possibles)
+						if ($line->subprice <= 0 && $oldsubprice > 0) {
+							$line->subprice = $oldsubprice;
+						}
+						$line->remise_percent = $discountrule->reduction;
+						// cette méthode appelle $object->updateline avec les bons paramètres
+						// selon chaque type d’objet (proposition, commande, facture)
+
+						// TODO : avant de mettre a jour, vérifier que c'est nécessaire car ça va peut-être déclencher des trigger inutilement
+						$resUp = DiscountRuleTools::updateLineBySelf($object, $line);
+						if($resUp<0){
+							$updaterror ++;
+							setEventMessage($langs->trans('DiscountUpdateLineError', $line->product_ref), 'errors');
+						}
+						else{
+							$updated ++;
+						}
+					} else {
+						continue;
+					}
+				}
+
+				if($updated>0){
+					setEventMessage($langs->trans('DiscountForLinesUpdated', $updated, count($object->lines)));
+				}
+				else if(empty($updated) && empty($updaterror)){
+					setEventMessage($langs->trans('NoDiscountToApply'));
+				}
+			}
+		}
+	}
+
+	/**
+	 * @param array $parameters
+	 * @param CommonObject $object
+	 * @param string $action
+	 * @param HookManager $hookmanager
+	 */
 	public function formEditProductOptions ($parameters, &$object, &$action, $hookmanager){
 		global $langs;
 		$langs->loadLangs(array('discountrules'));
@@ -106,6 +231,25 @@ class Actionsdiscountrules
 		}
 	}
 
+	/**
+	 * @param User $user
+	 * @param CommonObject $object
+	 * @return bool
+	 */
+	public static function checkUserUpdateObjectRight($user, $object, $rightToTest = 'creer'){
+		$right = false;
+		if($object->element == 'propal'){
+			$right = $user->rights->propal->{$rightToTest};
+		}
+		elseif($object->element == 'commande'){
+			$right = $user->rights->commande->{$rightToTest};
+		}
+		elseif($object->element == 'facture'){
+			$right = $user->rights->facture->{$rightToTest};
+		}
+		
+		return $right;
+	}
 
 	/**
 	 * Overloading the addMoreActionsButtons function : replacing the parent's function with the one below
@@ -126,11 +270,22 @@ class Actionsdiscountrules
 		if (in_array('propalcard', $context) || in_array('ordercard', $context) || in_array('invoicecard', $context) ) 
 		{
 			/** @var CommonObject $object */
+
+			// STATUS DRAFT ONLY
 		    if(!empty($object->statut)){
 		        return 0;
 		    }
-		    
-		    ?>
+
+		    // bouton permettant de rechercher et d'appliquer les règles de remises
+			// applicables aux lignes existantes
+			// TODO ajouter un droit type $user->rights->discountrules->[ex:propal]->updateDiscountsOnlines pour chaque elements gérés (propal commande facture)
+			if($conf->global->DISCOUNTRULES_ALLOW_APPLY_DISCOUNT_TO_ALL_LINES)
+			{
+				$updateDiscountBtnRight = self::checkUserUpdateObjectRight($user, $object);
+				$btnActionUrl = $_REQUEST['PHP_SELF'] . '?id=' . $object->id . '&action=askUpdateDiscounts&token=' . $_SESSION['newtoken'];
+				print dolGetButtonAction($langs->trans("UpdateDiscountsFromRules"),'','default',$btnActionUrl,'',$user->rights->discountrules->read && $updateDiscountBtnRight);
+			}
+			?>
 		    <!-- MODULE discountrules -->
 		    <link rel="stylesheet" type="text/css" href="<?php print dol_buildpath('discountrules/css/discountrules.css.php',1); ?>">
 			<script type="text/javascript">

--- a/class/discountrule.class.php
+++ b/class/discountrule.class.php
@@ -194,7 +194,7 @@ class DiscountRule extends CommonObject
 	        'visible'=>1,
 	        'enabled'=>1,
 	        'position'=>40,
-	        'notnull'=>1,
+	        'notnull'=>0,
 	        'default_value' => 1,
 	        'search'=>1,
 	    ),
@@ -622,6 +622,9 @@ class DiscountRule extends CommonObject
 	    else{
 	        $error++;
 	    }
+
+	    // null is forbiden
+		$this->from_quantity = doubleval($this->from_quantity);
 	    
 	    if ($error) {
 	        return -1 * $error;

--- a/class/discountrule.class.php
+++ b/class/discountrule.class.php
@@ -30,6 +30,7 @@ require_once DOL_DOCUMENT_ROOT . '/core/class/commonobject.class.php';
 require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
 require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
 require_once __DIR__ . '/../lib/discountrules.lib.php';
+require_once __DIR__ . '/discountruletools.class.php';
 
 /**
  * Class for discountrule
@@ -1004,6 +1005,7 @@ class DiscountRule extends CommonObject
 	 * @param int $fk_c_typent
 	 * @param int $fk_project
 	 * @return int <0 if KO, 0 if not found, > 0 if OK
+	 * @see $this->lastFetchByCritResult: last fetched database object
 	 */
 	public function fetchByCrit($from_quantity = 1, $fk_product = 0, $fk_category_product = 0, $fk_category_company = 0, $fk_company = 0, $date = 0, $fk_country = 0, $fk_c_typent = 0, $fk_project = 0)
 	{

--- a/langs/en_US/discountrules.lang
+++ b/langs/en_US/discountrules.lang
@@ -117,3 +117,10 @@ ProductPrice = Product price
 AllTypeEnt = All types
 ExplainPriorityOfRuleApplied = Keep in mind that the rule that will be proposed when adding a product in a document will always be the rule compatible with all the criteria and the most advantageous for the customer.
 
+#
+# Actions for Common documents
+#
+
+confirmUpdateDiscountsTitle = Update prices?
+confirmUpdateDiscounts = Update line prices according to discount rules?
+UpdateDiscountsFromRules = Apply discount rules

--- a/langs/fr_FR/discountrules.lang
+++ b/langs/fr_FR/discountrules.lang
@@ -42,6 +42,12 @@ DISCOUNTRULES_SEARCH_IN_INVOICES=Chercher les dernières réductions appliqués 
 DISCOUNTRULES_SEARCH_DAYS=Nombre de jours limite pour la recherche dans le passé (laisser vide ou 0 pour aucune limite)
 DISCOUNTRULES_SEARCH_QTY_EQUIV=Effectuer la recherche pour des quantités inférieures ou égales du même produit/service
 
+
+# SETUP IN DEVELOPMENT
+ParameterForDevelopmentOrDeprecated = Paramettres en développement
+ParameterForDevelopmentOrDeprecatedHelp = Attention les paramettres suivants sont en développements utilisations seulement si vous savez ce que vous faites.
+DISCOUNTRULES_ALLOW_APPLY_DISCOUNT_TO_ALL_LINES = Permettre de mettre à jours toutes les remises d'un document avec les dernières règles en vigueurs
+
 #
 # Page À propos
 #
@@ -121,3 +127,16 @@ ActiveRuleProject = Règle de projet active
 Customer = client
 actionClickMeDiscountrule = Cliquez sur l'icône pour affecter la réduction
 AvailableDiscountInfo = Infos sur la remise applicable
+
+
+#
+# Actions for Common documents
+#
+
+confirmUpdateDiscountsTitle = Mettre à jour les prix ?
+confirmUpdateDiscounts = Voulez-vous vraiment mettre à jour les prix des lignes en application des règles de remises ?
+UpdateDiscountsFromRules = Réappliquer les remises
+DiscountUpdateLineError = Erreur lors de la mise à jour de la ligne %s
+DiscountForLinesUpdated = Lines mises à jour : %s
+NoDiscountToApply = Aucune remise à appliquer
+NotEnoughtRights = vos droits utilisateur ne vous permettent pas de réaliser cette action


### PR DESCRIPTION
# NEW

On draft proposals, orders and invoices, a new button enables the user to re-apply relevant discount rules to all the document's lines in one go.

Cette fonctionnalité est issue d'une PR précédemment revert.
Elle est maintenant intégrée et activable via la zone  "Work in progress" des configurations du module.
Cette fonctionnalité est pour moi incomplète mais intéressante pour le module. 
Pour voir l'option MAIN_FEATURE_LEVEL >= 2