### PR TITLE
Fix 2.11 check document date

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Not Released
 
+- FIX : Prise en compte de la date du document comme date référence pour la recherche des règles de remise + ajout de conf pour rétro cohérence comportementale *09/11/2021* - 2.11.2
 - FIX : afficher les colonnes "Prix Ht à appliquer" et "Remise fixe" dans la liste des règles de remise sur la fiche Tiers et sur la fiche Produit *23/09/2021* - 2.11.1
 - NEW : un onglet “Règles de prix catalogue” sera ajouté sur les fiches tiers. Cet onglet proposera un tableau des règles de remises applicables à ce client selon qu’elles s’appliquent directement à lui ou à un attribut qu’il possède (catégorie, type de tiers, pays ou projet). *23/08/2021* - 2.11.0
 - NEW : Search result return now also current product price and default customer reduction *29/07/2021* - 2.10.0

--- a/admin/setup.php
+++ b/admin/setup.php
@@ -113,6 +113,9 @@ _printInputFormPart($confKey, '', '', array(), $type, 'PriorityRuleRankHelp');
 $metas = array( 'type' => 'number', 'step' => '1', 'min' => 0 );
 _printInputFormPart('DISCOUNTRULES_SEARCH_DAYS', '', '', $metas);
 
+// conf qui permet de garder le comportement originel du module qui recherchait les règles de remises en prenant comme référence la date courante
+_printOnOff('DISCOUNTRULES_SEARCH_WITHOUT_DOCUMENTS_DATE');
+
 
 print '</table>';
 

--- a/class/actions_discountrules.class.php
+++ b/class/actions_discountrules.class.php
@@ -124,6 +124,10 @@ class Actionsdiscountrules
 				$TCompanyCat = DiscountRule::getAllConnectedCats($TCompanyCat);
 				$updated = 0;
 				$updaterror = 0;
+
+				$dateTocheck = time();
+				if (empty($conf->global->DISCOUNTRULES_SEARCH_WITHOUT_DOCUMENTS_DATE)) $dateTocheck = $object->date;
+
 				foreach ($object->lines as $line) {
 					/** @var PropaleLigne|OrderLine|FactureLigne $line */
 
@@ -140,7 +144,7 @@ class Actionsdiscountrules
 							$TProductCat,
 							$TCompanyCat,
 							$object->socid,
-							time(),
+							$dateTocheck,
 							$client->country_id,
 							$client->typent_id,
 							$object->fk_project
@@ -192,11 +196,16 @@ class Actionsdiscountrules
 	 * @param HookManager $hookmanager
 	 */
 	public function formEditProductOptions ($parameters, &$object, &$action, $hookmanager){
-		global $langs;
+		global $langs, $conf;
 		$langs->loadLangs(array('discountrules'));
 		$context = explode(':', $parameters['context']);
+
 		if (in_array('propalcard', $context) || in_array('ordercard', $context) || in_array('invoicecard', $context) && $action != "edit")
 		{
+
+			$dateTocheck = time();
+			if (empty($conf->global->DISCOUNTRULES_SEARCH_WITHOUT_DOCUMENTS_DATE)) $dateTocheck = $object->date;
+
 			?>
 			<!-- handler event jquery on 'qty' udpating values for product  -->
 			<script type="text/javascript">
@@ -209,7 +218,7 @@ class Actionsdiscountrules
 					let FormmUpdateLine = 	!document.getElementById("addline");
 					// si nous sommes dans le formulaire Modification
 					if (FormmUpdateLine) {
-						DiscountRule.fetchDiscountOnEditLine('<?php print $object->element; ?>',idLine,idProd,<?php print intval($object->socid); ?>,<?php print intval($object->fk_project); ?>,<?php print intval($object->country_id); ?>);
+						DiscountRule.fetchDiscountOnEditLine('<?php print $object->element; ?>',idLine,idProd,<?php print intval($object->socid); ?>,<?php print intval($object->fk_project); ?>,<?php print intval($object->country_id); ?>,<?php print $dateTocheck; ?>);
 					}
 				});
 
@@ -284,6 +293,9 @@ class Actionsdiscountrules
 				print dolGetButtonAction($langs->trans("UpdateDiscountsFromRules"),'','default',$btnActionUrl,'',$user->rights->discountrules->read && $updateDiscountBtnRight);
 			}
 
+			$dateTocheck = time();
+			if (empty($conf->global->DISCOUNTRULES_SEARCH_WITHOUT_DOCUMENTS_DATE)) $dateTocheck = $object->date;
+
 			// ADD DISCOUNT RULES SEARCH ON DOCUMENT ADD LINE FORM
 			?>
 		    <!-- MODULE discountrules -->
@@ -296,7 +308,7 @@ class Actionsdiscountrules
 						let defaultCustomerReduction = '<?php print floatval($object->thirdparty->remise_percent); ?>';
 						let fk_company = '<?php print intval($object->socid); ?>';
 						let fk_project = '<?php print intval($object->fk_project); ?>';
-						DiscountRule.discountUpdate($('#idprod').val(), fk_company, fk_project, '#qty', '#price_ht', '#remise_percent', defaultCustomerReduction);
+						DiscountRule.discountUpdate($('#idprod').val(), fk_company, fk_project, '#qty', '#price_ht', '#remise_percent', defaultCustomerReduction, '<?php echo $dateTocheck; ?>');
 					});
 				});
 			</script>

--- a/class/discountSearch.class.php
+++ b/class/discountSearch.class.php
@@ -126,10 +126,13 @@ class DiscountSearch
 	 * @param bool  $nocache
 	 * @return DiscountSearchResult|int
 	 */
-	public function search($qty = 0, $fk_product = 0, $fk_company = 0, $fk_project = 0, $TProductCat = array(), $TCompanyCat = array(), $fk_c_typent = 0, $fk_country = 0, $nocache = 0){
+	public function search($qty = 0, $fk_product = 0, $fk_company = 0, $fk_project = 0, $TProductCat = array(), $TCompanyCat = array(), $fk_c_typent = 0, $fk_country = 0, $nocache = 0, $date = ''){
 		$fk_product = intval($fk_product);
 		$this->qty = $qty;
 		$this->fk_product = $fk_product;
+
+		if (empty($date)) $this->date = time();
+		else $this->date = $date;
 
 		if(!empty($fk_product)){
 			$res = $this->feedByProduct($fk_product, $nocache);
@@ -316,7 +319,7 @@ class DiscountSearch
 		$this->debugLog($TCompanyCat); // pass get var activatedebug or set activatedebug to show log
 
 		$discountRes = new DiscountRule($this->db);
-		$res = $discountRes->fetchByCrit($this->qty, $this->fk_product, $TAllProductCat, $TCompanyCat, $this->fk_company,  time(), $this->fk_country, $this->fk_c_typent, $this->fk_project);
+		$res = $discountRes->fetchByCrit($this->qty, $this->fk_product, $TAllProductCat, $TCompanyCat, $this->fk_company,  $this->date, $this->fk_country, $this->fk_c_typent, $this->fk_project);
 		$this->debugLog($discountRes->error);
 		if ($res > 0) {
 			$this->discountRule = $discountRes;

--- a/class/discountSearch.class.php
+++ b/class/discountSearch.class.php
@@ -124,6 +124,7 @@ class DiscountSearch
 	 * @param int   $fk_c_typent
 	 * @param int   $fk_country
 	 * @param bool  $nocache
+	 * @param string $date
 	 * @return DiscountSearchResult|int
 	 */
 	public function search($qty = 0, $fk_product = 0, $fk_company = 0, $fk_project = 0, $TProductCat = array(), $TCompanyCat = array(), $fk_c_typent = 0, $fk_country = 0, $nocache = 0, $date = ''){

--- a/class/discountSearch.class.php
+++ b/class/discountSearch.class.php
@@ -131,7 +131,7 @@ class DiscountSearch
 		$this->qty = $qty;
 		$this->fk_product = $fk_product;
 
-		if (empty($date)) $this->date = time();
+		if (empty($date) && empty($this->date)) $this->date = time();
 		else $this->date = $date;
 
 		if(!empty($fk_product)){

--- a/class/discountSearch.class.php
+++ b/class/discountSearch.class.php
@@ -131,8 +131,8 @@ class DiscountSearch
 		$this->qty = $qty;
 		$this->fk_product = $fk_product;
 
-		if (empty($date) && empty($this->date)) $this->date = time();
-		else $this->date = $date;
+		if (empty($this->date)) $this->date = time();
+		if (! empty($date)) $this->date = $date;
 
 		if(!empty($fk_product)){
 			$res = $this->feedByProduct($fk_product, $nocache);

--- a/core/modules/moddiscountrules.class.php
+++ b/core/modules/moddiscountrules.class.php
@@ -382,7 +382,7 @@ class moddiscountrules extends DolibarrModules
 			&& empty($conf->global->DISCOUNT_RULES_LAST_VERSION)
 		) {
 			// on set la conf pour maintenir le comportement historique (rétro cohérence du comportement)
-			$result = dolibarr_set_const($this->db, 'DISCOUNTRULES_SEARCH_WITHOUT_DOCUMENTS_DATE', '1', 'chaine', 0, '', 0);
+			$result = dolibarr_set_const($this->db, 'DISCOUNTRULES_SEARCH_WITHOUT_DOCUMENTS_DATE', '1', 'chaine', 0, '', $conf->entity);
 		}
 
 		$sql = array();

--- a/core/modules/moddiscountrules.class.php
+++ b/core/modules/moddiscountrules.class.php
@@ -73,7 +73,7 @@ class moddiscountrules extends DolibarrModules
 
 		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated' or a version string like 'x.y.z'
 
-		$this->version = '2.11.1';
+		$this->version = '2.11.2';
 
 		// Key used in llx_const table to save module status enabled/disabled (where discountrules is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);

--- a/core/modules/moddiscountrules.class.php
+++ b/core/modules/moddiscountrules.class.php
@@ -140,7 +140,7 @@ class moddiscountrules extends DolibarrModules
 		//                             1=>array('discountrules_MYNEWCONST2','chaine','myvalue','This is another constant to add',0, 'current', 1)
 		// );
 		$this->const = array(
-			1=>array('DISCOUNT_RULES_LAST_VERSION', 'chaine', $this->version, 'Last version reload', 0, 'allentities', 0)
+			1=>array('DISCOUNTRULES_MOD_LAST_RELOAD_VERSION', 'chaine', $this->version, 'Last version reload', 0, 'allentities', 0)
 		);
 
 		// Array to add new pages in new tabs
@@ -371,6 +371,8 @@ class moddiscountrules extends DolibarrModules
 
 		require_once DOL_DOCUMENT_ROOT . "/core/lib/admin.lib.php";
 
+		// TODO à retirer après la version 3.0
+		// ----------------------------------------------------------
 		$sql = "SELECT * FROM ".MAIN_DB_PREFIX."discountrule WHERE 1 LIMIT 1";
 		$resql = $this->db->query($sql);
 
@@ -379,11 +381,12 @@ class moddiscountrules extends DolibarrModules
 
 		if (
 			!$first_install && empty($conf->global->DISCOUNTRULES_SEARCH_WITHOUT_DOCUMENTS_DATE)
-			&& empty($conf->global->DISCOUNT_RULES_LAST_VERSION)
+			&& empty($conf->global->DISCOUNTRULES_MOD_LAST_RELOAD_VERSION)
 		) {
 			// on set la conf pour maintenir le comportement historique (rétro cohérence du comportement)
 			$result = dolibarr_set_const($this->db, 'DISCOUNTRULES_SEARCH_WITHOUT_DOCUMENTS_DATE', '1', 'chaine', 0, '', $conf->entity);
 		}
+		// ----------------------------------------------------------
 
 		$sql = array();
 

--- a/core/modules/moddiscountrules.class.php
+++ b/core/modules/moddiscountrules.class.php
@@ -73,7 +73,7 @@ class moddiscountrules extends DolibarrModules
 
 		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated' or a version string like 'x.y.z'
 
-		$this->version = '2.11.0';
+		$this->version = '2.11.1';
 
 		// Key used in llx_const table to save module status enabled/disabled (where discountrules is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
@@ -139,9 +139,9 @@ class moddiscountrules extends DolibarrModules
 		// Example: $this->const=array(0=>array('discountrules_MYNEWCONST1','chaine','myvalue','This is a constant to add',1),
 		//                             1=>array('discountrules_MYNEWCONST2','chaine','myvalue','This is another constant to add',0, 'current', 1)
 		// );
-		/*$this->const = array(
-			1=>array('discountrules_MYCONSTANT', 'chaine', 'avalue', 'This is a constant to add', 1, 'allentities', 1)
-		);*/
+		$this->const = array(
+			1=>array('DISCOUNT_RULES_LAST_VERSION', 'chaine', $this->version, 'Last version reload', 0, 'allentities', 0)
+		);
 
 		// Array to add new pages in new tabs
 		// Example: $this->tabs = array('objecttype:+tabname1:Title1:mylangfile@discountrules:$user->rights->discountrules->read:/discountrules/mynewtab1.php?id=__ID__',  					// To add a new tab identified by code tabname1
@@ -367,6 +367,24 @@ class moddiscountrules extends DolibarrModules
 	 */
 	public function init($options='')
 	{
+		global $conf;
+
+		require_once DOL_DOCUMENT_ROOT . "/core/lib/admin.lib.php";
+
+		$sql = "SELECT * FROM ".MAIN_DB_PREFIX."discountrule WHERE 1 LIMIT 1";
+		$resql = $this->db->query($sql);
+
+		$first_install = false;
+		if ($this->db->lasterrno() == 'DB_ERROR_NOSUCHTABLE') $first_install = true; // première install => la table n'existe pas
+
+		if (
+			!$first_install && empty($conf->global->DISCOUNTRULES_SEARCH_WITHOUT_DOCUMENTS_DATE)
+			&& empty($conf->global->DISCOUNT_RULES_LAST_VERSION)
+		) {
+			// on set la conf pour maintenir le comportement historique (rétro cohérence du comportement)
+			$result = dolibarr_set_const($this->db, 'DISCOUNTRULES_SEARCH_WITHOUT_DOCUMENTS_DATE', '1', 'chaine', 0, '', 0);
+		}
+
 		$sql = array();
 
 		$this->_load_tables('/discountrules/sql/');

--- a/js/discountrules.js.php
+++ b/js/discountrules.js.php
@@ -169,10 +169,9 @@ var DiscountRule = {};
 	o.discountlang = <?php print json_encode($translate) ?>;
 	o.advanceProductSearchConfig = <?php print json_encode($confToJs) ?>;
 
-	o.fetchDiscountOnEditLine = function (element, idLine, idProd,fkCompany,fkProject,fkCountry) {
+	o.fetchDiscountOnEditLine = function (element, idLine, idProd,fkCompany,fkProject,fkCountry,date) {
 
 		if (idProd == undefined || $('#qty') == undefined) return 0;
-
 
 		var lastidprod = 0;
 		var lastqty = 0;
@@ -191,7 +190,8 @@ var DiscountRule = {};
 				'fk_product': idProd,
 				'fk_company': fkCompany,
 				'fk_project' : fkProject,
-				'fk_country' : fkCountry
+				'fk_country' : fkCountry,
+				'date':date
 			};
 
 
@@ -321,7 +321,7 @@ var DiscountRule = {};
 
 	o.lastidprod = 0;
 	o.lastqty = 0;
-	o.discountUpdate = function (idprod, fk_company, fk_project, qtySelector = '#qty', subpriceSelector = '#price_ht', remiseSelector = '#remise_percent', defaultCustomerReduction = 0){
+	o.discountUpdate = function (idprod, fk_company, fk_project, qtySelector = '#qty', subpriceSelector = '#price_ht', remiseSelector = '#remise_percent', defaultCustomerReduction = 0, date=''){
 
 		if(idprod == null || idprod == 0 || $(qtySelector) == undefined ){  return 0; }
 
@@ -344,6 +344,7 @@ var DiscountRule = {};
 					'qty': qty,
 					'fk_company': fk_company,
 					'fk_project' : fk_project,
+					'date' : date
 				}
 			})
 				.done(function( data ) {

--- a/langs/en_US/discountrules.lang
+++ b/langs/en_US/discountrules.lang
@@ -42,6 +42,7 @@ DISCOUNTRULES_SEARCH_IN_INVOICES=Find the latest discounts applied to <strong> I
 DISCOUNTRULES_SEARCH_DAYS=Number of days limit for searching in the past (leave empty or 0 for no limit)
 DISCOUNTRULES_SEARCH_IN_DOCUMENTS_QTY_EQUIV=Search for lower or equal quantities of the same product / service
 DISCOUNTRULES_SEARCH_IN_DOCUMENTS_PROJECT_EQUIV=Search same project in documents
+DISCOUNTRULES_SEARCH_WITHOUT_DOCUMENTS_DATE=Search rules for current date instead of document date
 
 #
 # Page À propos

--- a/langs/fr_FR/discountrules.lang
+++ b/langs/fr_FR/discountrules.lang
@@ -47,7 +47,7 @@ DISCOUNTRULES_SEARCH_IN_INVOICES=Chercher les dernières réductions appliqués 
 DISCOUNTRULES_SEARCH_DAYS=Nombre de jours limite pour la recherche dans le passé (laisser vide ou 0 pour aucune limite)
 DISCOUNTRULES_SEARCH_IN_DOCUMENTS_QTY_EQUIV = Effectuer la recherche pour des quantités inférieures ou égales du même produit/service
 DISCOUNTRULES_SEARCH_IN_DOCUMENTS_PROJECT_EQUIV = Limiter la recherche de documents aux mêmes projets.
-
+DISCOUNTRULES_SEARCH_WITHOUT_DOCUMENTS_DATE=Rechercher des règles en fonction de la date courante et non en fonction de la date du document
 
 # SETUP IN DEVELOPMENT
 ParameterForDevelopmentOrDeprecated = Paramettres en développement

--- a/scripts/interface.php
+++ b/scripts/interface.php
@@ -76,9 +76,10 @@ if ($action === 'product-discount') {
 	$fk_country = GETPOST('fk_country', 'int');
 	$qty = GETPOST('qty', 'int');
 	$fk_c_typent = GETPOST('fk_c_typent', 'int');
+	$date = GETPOST('date', 'none');
 
 	$search = new DiscountSearch($db);
-	$jsonResponse = $search->search($qty, $fk_product, $fk_company, $fk_project, array(), array(), $fk_c_typent, $fk_country);
+	$jsonResponse = $search->search($qty, $fk_product, $fk_company, $fk_project, array(), array(), $fk_c_typent, $fk_country, 0, $date);
 
 	// Mise en page du résultat
 	$jsonResponse->tpMsg = getDiscountRulesInterfaceMessageTpl($langs, $jsonResponse, $action);


### PR DESCRIPTION
- FIX : Prise en compte de la date du document comme date référence pour la recherche des règles de remise + ajout de conf pour rétro cohérence comportementale *09/11/2021* - 2.11.2
