### PR TITLE
FIX : DA022683 - Date de début des règle de remise sur import 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,8 +5,8 @@
 
 
 ## 2.19
-
-- NEW : Add field "product_price" in discount rules list  *07/09/2022* - 2.19.0
+- FIX : Set des heures de dates de début de remise à 0 pour que ces remises soient prisent en compte dès le premier jour - *15/12/2022* - 2.19.1
+- NEW : Add field "product_price" in discount rules list - *07/09/2022* - 2.19.0
 
 ## 2.18
 

--- a/class/importrule.class.php
+++ b/class/importrule.class.php
@@ -690,8 +690,7 @@ class ImportRule{
 
 		$date = DateTime::createFromFormat('d/m/Y', $dateFrom);
 		$timestamp = $date->getTimestamp();
-
-		$objDiscount->date_from = dol_print_date($timestamp, "%Y-%m-%d %H:%M:%S");
+		$objDiscount->date_from = dol_print_date($timestamp, "%Y-%m-%d 00:00:00");
 	}
 
 	/**

--- a/core/modules/moddiscountrules.class.php
+++ b/core/modules/moddiscountrules.class.php
@@ -73,7 +73,7 @@ class moddiscountrules extends DolibarrModules
 
 		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated' or a version string like 'x.y.z'
 
-		$this->version = '2.19.0';
+		$this->version = '2.19.1';
 
 		// Key used in llx_const table to save module status enabled/disabled (where discountrules is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);


### PR DESCRIPTION
### FIX : DA022683 - Date de début des règle de remise sur import 

Il n'étais pas possible 'utiliser les règles de remise le jour même de leur début en fonction de l'heure à laquelle avait été fait l'import : 
Le système prenait l'heure à laquelle était fait l'import comme heure de début d'application des règles de prix. 

J'ai donc changé ça pour que le système prenne l'heure la plus petite possible et donc pour que la règle de prix soit applicable le plus tôt possible (en fonction de sa date de début) 